### PR TITLE
Replace MPI_2COMPLEX, MPI_2DOUBLE_COMPLEX to MPI_COMPLEX, MPI_DOUBLE_COMPLEX

### DIFF
--- a/ext/mpi/mpi.c
+++ b/ext/mpi/mpi.c
@@ -69,11 +69,11 @@
       buffer = (void*)((char*)buffer + off*8);\
       break;\
     case NA_SCOMPLEX:\
-      typ = MPI_2COMPLEX;\
+      typ = MPI_COMPLEX;\
       buffer = (void*)((char*)buffer + off*8);\
       break;\
     case NA_DCOMPLEX:\
-      typ = MPI_2DOUBLE_COMPLEX;\
+      typ = MPI_DOUBLE_COMPLEX;\
       buffer = (void*)((char*)buffer + off*16);\
       break;\
     default:\


### PR DESCRIPTION
* MPI_2COMPLEX and MPI_2DOUBLE_COMPLEX are not MPI standard types. This can cause problems, e.g.
  - https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1076063